### PR TITLE
Use Hasura Admin secret for deleting userdata (CU-2m9fjey)

### DIFF
--- a/src/pages/api/delete-user-data-files.ts
+++ b/src/pages/api/delete-user-data-files.ts
@@ -42,7 +42,7 @@ export default async (
       process.env.NEXT_PUBLIC_HASURA_GRAPHQL_DOCKER_URL as string,
       {
         headers: {
-          Authorization: `Bearer ${hasuraToken}`,
+          "x-hasura-admin-secret": process.env.HASURA_ADMIN_SECRET as string,
         },
       },
     );


### PR DESCRIPTION
### Description

Use Hasura Admin secret for deleting userdata, since the worker role doesn't have permission to do this.

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
