### PR TITLE
Add '--ignore-engines' flag to 'yarn install' in dockerfile to avoid engine incompatability error

### DIFF
--- a/development.dockerfile
+++ b/development.dockerfile
@@ -24,7 +24,7 @@ RUN chown -R node:node /app
 
 USER node
 
-RUN yarn install
+RUN yarn install --ignore-engines
 
 EXPOSE 5000
 


### PR DESCRIPTION
### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

This PR resolves #109 by adding the `--ignore-engines` flag to `yarn install` in the `development.dockerfile`. Without this flag, running a script that builds the docker image throws an error related to a node engine incompatibility issue. The updated behavior is that the docker image is built without errors.

### Other changes

_Describe any minor or "drive-by" changes here._

N/A

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

In addition to pre-commit and push unit tests passing successfully, this was tested by running the `./scripts/dc-start-vault-gui` script from the development-stack directory which starts the vault-gui app. Then, the app was accessed on [http://localhost:5000/](http://localhost:5000/) and data was uploaded successfully to the vault.

### Related issues

- Fixes #109

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

N/A
