### PR TITLE
Add user information to Share API response (CU-2veb7qv)

### DIFF
--- a/src/pages/share/index.tsx
+++ b/src/pages/share/index.tsx
@@ -135,6 +135,11 @@ const SendPage: NextPage = () => {
     const payloadToSend: DataPipeline.VaultMessage = {
       messageType: DataPipeline.VaultMessageType.SHARE_RESPONSE_SUCCESSFUL,
       payload,
+      user: {
+        id: user?.id,
+        email: user?.emailAddress,
+        name: user?.name,
+      },
     };
 
     if (!windowRef?.current) return;

--- a/src/types/DataPipeline.ts
+++ b/src/types/DataPipeline.ts
@@ -22,6 +22,11 @@ enum Status {
 interface VaultMessage {
   messageType: VaultMessageType;
   payload: any;
+  user?: {
+    id: string;
+    email?: string;
+    name?: string;
+  };
 }
 
 export { Stage, Status, VaultMessageType };


### PR DESCRIPTION
### Description

Adds the following user information to the Share API response so apps have context about a user. 

```
email: "kahtaf@vana.com"
id: "388fff27-9e80-47f2-ab86-2cd96b07a64b"
name: "Kahtaf Alam"
```

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
