### PR TITLE
Improve Metamask copy on desktop vs mobile (CU-2uc3rta)

### DIFF
--- a/src/components/Layout/LayoutApp.tsx
+++ b/src/components/Layout/LayoutApp.tsx
@@ -1,7 +1,6 @@
 import { Icon } from "@iconify/react";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
-import useMeasure from "react-use-measure";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import tw from "twin.macro";
 
@@ -14,6 +13,7 @@ import {
   styledNavButton,
   styledTrigger,
 } from "src/components";
+import { useDeviceDetect } from "src/hooks";
 
 interface Props {
   children?: React.ReactNode;
@@ -30,19 +30,7 @@ const LayoutApp = ({ children, renderNavMobile }: Props) => {
   const isSendPath = router.pathname === "/share";
 
   // Determine if viewport isMobile
-  const [ref, { width }] = useMeasure();
-  const [isMobile, setIsMobile] = useState(false);
-
-  // `setIsMobile` once only on initial page load in production mode
-  // …but we add width to deps for local development
-  // TODO: how can we use the node.production flag here?
-  useEffect(() => {
-    if (width < 640) {
-      setIsMobile(true);
-    } else {
-      setIsMobile(false);
-    }
-  }, [width]);
+  const { isMobileViewport } = useDeviceDetect();
 
   // Reset DropdownMenuControlled on route change
   const [isOpen, setIsOpen] = useState(false);
@@ -52,7 +40,7 @@ const LayoutApp = ({ children, renderNavMobile }: Props) => {
     <>
       {/* NAVBAR */}
       {!isSendPath && (
-        <div ref={ref} tw="fixed top-0 left-0 right-0 bg-background">
+        <div tw="fixed top-0 left-0 right-0 bg-background">
           <div tw="mx-auto max-w-canvasWidth">
             <Navbar />
           </div>
@@ -71,7 +59,7 @@ const LayoutApp = ({ children, renderNavMobile }: Props) => {
       </div>
 
       {/* MOBILE NAV */}
-      {renderNavMobile && !isSendPath && isMobile && (
+      {renderNavMobile && !isSendPath && isMobileViewport && (
         <div tw="fixed bottom-inset right-0">
           <div tw="px-inset h-navH">
             <DropdownMenuControlled
@@ -105,7 +93,7 @@ const LayoutApp = ({ children, renderNavMobile }: Props) => {
       )}
 
       {/* MOBILE TYPEFORM */}
-      {renderNavMobile && !isSendPath && isMobile && (
+      {renderNavMobile && !isSendPath && isMobileViewport && (
         <div tw="fixed bottom-inset left-0">
           <div tw="px-inset h-navH flex items-center">
             <NavAsideBetaTypeformMobile />

--- a/src/components/UserAccess/UserContext.tsx
+++ b/src/components/UserAccess/UserContext.tsx
@@ -16,6 +16,7 @@ import { createContext, useContext, useEffect, useState } from "react";
 import { Link, ToastDefault } from "src/components";
 import config from "src/config";
 import { Users } from "src/graphql/generated";
+import { useDeviceDetect } from "src/hooks";
 import {
   displayMetamaskLoginModal,
   getJwtPayload,
@@ -85,6 +86,7 @@ const UserProvider = ({ children }: UserProviderProps) => {
   const [loginError, setLoginError] = useState(false);
   const [isInitialAccountLogin, setIsInitialAccountLogin] = useState(false);
   const { resolvedTheme } = useTheme();
+  const { isMobileUserAgent } = useDeviceDetect();
 
   // Due to clashes between useTheme and web3Auth.uiConfig types,
   // definitively set the theme to either light or dark
@@ -213,7 +215,7 @@ const UserProvider = ({ children }: UserProviderProps) => {
 
     web3AuthInstance.on(LOGIN_MODAL_EVENTS.MODAL_VISIBILITY, (isVisible) => {
       setIsWeb3AuthLoading(isVisible);
-      displayMetamaskLoginModal(isVisible);
+      displayMetamaskLoginModal(isVisible, isMobileUserAgent);
       if (!isVisible) {
         setIsSignUp(false);
       }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from "./useDeviceDetect";
 export * from "./useExpireJWTs";

--- a/src/hooks/useDeviceDetect.ts
+++ b/src/hooks/useDeviceDetect.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useState } from "react";
+
+interface DeviceDetect {
+  isMobileUserAgent: boolean;
+  isMobileViewport: boolean;
+}
+
+const useDeviceDetect = (): DeviceDetect => {
+  const userAgent =
+    typeof navigator === "undefined" ? "SSR" : navigator.userAgent;
+  const deviceProperties = detectDevice(userAgent);
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
+
+  const onWindowSizeChanged = useCallback(() => {
+    setIsMobileViewport(window.innerWidth < 640);
+  }, []);
+
+  useEffect(() => {
+    onWindowSizeChanged();
+    window.addEventListener("resize", onWindowSizeChanged, true);
+
+    return () => {
+      window.removeEventListener("resize", onWindowSizeChanged, true);
+    };
+  }, []);
+
+  return {
+    isMobileViewport,
+    isMobileUserAgent: deviceProperties.isMobile(),
+  } as DeviceDetect;
+};
+
+/**
+ * Categorize device based on user agent
+ * @param userAgent
+ * @returns
+ */
+const detectDevice = (userAgent: string) => {
+  const isAndroid = (): boolean => Boolean(userAgent.match(/Android/i));
+  const isIos = (): boolean => Boolean(userAgent.match(/iPhone|iPad|iPod/i));
+  const isOpera = (): boolean => Boolean(userAgent.match(/Opera Mini/i));
+  const isWindows = (): boolean => Boolean(userAgent.match(/IEMobile/i));
+  const isSSR = (): boolean => Boolean(userAgent.match(/SSR/i));
+
+  const isMobile = (): boolean =>
+    Boolean(isAndroid() || isIos() || isOpera() || isWindows());
+  const isDesktop = (): boolean => Boolean(!isMobile() && !isSSR());
+  return {
+    isMobile,
+    isDesktop,
+    isAndroid,
+    isIos,
+    isSSR,
+  };
+};
+
+export { useDeviceDetect };

--- a/src/utils/identity/displayMetamaskLoginModal.ts
+++ b/src/utils/identity/displayMetamaskLoginModal.ts
@@ -2,16 +2,20 @@ const metamaskDisabledIconHtml = `<li class="w3a-adapter-item" id="metamask-unav
     <button type="button" class="w3a-button w3a-button--icon" style="opacity: 30%;">
         <img src="https://images.web3auth.io/login-metamask.svg" height="auto" width="auto" alt="login-metamask">
     </button>
-    <p class="w3a-adapter-item__label">MetaMask*</p>
+    <p class="w3a-adapter-item__label">MetaMask</p>
 </li>`;
 
-const metamaskFooterHtml = `<small>*Log in to Vana on the MetaMask browser</small>`;
+const metamaskDesktopFooterHtml = `<small>Log in with <a href="https://metamask.io/">MetaMask</a> browser extension</small>`;
+const metamaskMobileFooterHtml = `<small>Log in on the <a href="https://metamask.io/">MetaMask</a> app</small>`;
 
 /**
  * Displays a greyed out MetaMask icon on the Web3Auth login modal
  * @param isModalVisible
  */
-const displayMetamaskLoginModal = (isModalVisible: boolean) => {
+const displayMetamaskLoginModal = (
+  isModalVisible: boolean,
+  isMobileUserAgent: boolean,
+) => {
   setTimeout(() => {
     const web3AuthModalContent = document.querySelector(
       ".w3a-modal__content.w3ajs-content",
@@ -31,7 +35,13 @@ const displayMetamaskLoginModal = (isModalVisible: boolean) => {
           // MetaMask is not available, display help text
           adapterList.innerHTML += metamaskDisabledIconHtml;
           adapterList?.parentNode?.insertBefore(
-            document.createRange().createContextualFragment(metamaskFooterHtml),
+            document
+              .createRange()
+              .createContextualFragment(
+                isMobileUserAgent
+                  ? metamaskMobileFooterHtml
+                  : metamaskDesktopFooterHtml,
+              ),
             adapterList.nextSibling,
           );
         }


### PR DESCRIPTION
### Description

- Introduce `useDeviceDetect()` for detecting mobile vs desktop
- Improve Metamask help text for desktop vs mobile

<img width="346" alt="image" src="https://user-images.githubusercontent.com/5796181/192564847-58b7d1c5-549b-443c-94df-80814ebda886.png">

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
